### PR TITLE
Fix issue #192: Remove all the coments in the DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and test
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
This pull request fixes #192.

The issue has been successfully resolved. The changes made to the Dockerfile removed all comments (lines starting with #) while preserving all the functional Docker instructions. Specifically:

1. All 13 comment lines that were prefixed with # have been removed
2. The actual Docker commands (FROM, WORKDIR, COPY, RUN, ENV, USER, CMD) remain intact and unchanged
3. The functionality of the Dockerfile remains exactly the same since comments are purely descriptive and do not affect the build process
4. The file structure with the two build stages (build and production) is preserved

The resulting Dockerfile is now cleaner and more concise while maintaining all the necessary instructions for building and running the application. Since the original issue request was simply to "Remove all the comments in the DockerFile" and this has been completely accomplished without affecting functionality, this can be considered a successful resolution.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌