### PR TITLE
Fix issue #194: Remove all the coments in the DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and test
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and production
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
This pull request fixes #194.

The changes successfully resolved the issue by removing all comments from both Dockerfile and src/Dockerfile. The diffs show that all lines beginning with # were removed, while preserving the actual functional Dockerfile instructions. This includes:

1. Removal of descriptive comments about image usage and stages
2. Removal of explanatory comments about directory creation
3. Removal of comments describing dependency installation steps
4. Removal of section divider comments
5. Removal of comments explaining copy operations and startup commands

The resulting Dockerfiles maintain identical functionality but are now clean of all comments, exactly matching the issue request. The files still contain all necessary instructions for building and running the application, just without the explanatory text. The diff clearly shows every comment line was removed (indicated by the - marks before lines starting with #) while preserving all actual Docker commands.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌