### PR TITLE
Fix issue #194: Remove all the coments in the DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and test
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and production
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
This pull request fixes #194.

The changes fully resolve the issue by removing all comments from both Dockerfile and src/Dockerfile while preserving the exact same functionality. Specifically:

1. All lines starting with # have been removed from both files
2. The section divider comment (###################) has been removed
3. The actual Docker instructions (FROM, WORKDIR, COPY, RUN, ENV, USER, CMD) remain unchanged
4. The build stages (build and production) are preserved
5. The execution order and dependencies between steps remain the same

The Dockerfiles will produce identical container images as before since comments are purely for human readability and do not affect Docker's build process. The multi-stage build structure, dependency installation, build process, and production deployment setup all remain functionally identical - just without the explanatory comments. This directly and completely addresses the original issue request to "Remove all the comments in the DockerFile".

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌