### PR TITLE
Fix issue #194: Remove all the coments in the DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and test
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and production
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
This pull request fixes #194.

The changes clearly show that all comment lines (those starting with #) have been removed from both Dockerfile and src/Dockerfile while preserving all the functional commands. Specifically:

1. All lines that began with # have been removed from both files
2. The actual Docker instructions (FROM, WORKDIR, COPY, RUN, ENV, USER, CMD) remain intact
3. The multi-stage build structure is preserved
4. The functionality of the Dockerfile remains unchanged since comments are purely descriptive and don't affect execution

The diff shows a reduction from 43 lines to 26 lines in both files, with the only differences being the removal of comments. The Dockerfiles will build exactly the same images as before, just without the explanatory text. This directly and completely addresses the original issue request to "Remove all the comments in the DockerFile."

The changes are complete and correct - every single comment has been removed while maintaining the working Dockerfile structure. No additional changes are needed to fulfill the requirements of the issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌