### PR TITLE
Fix issue #194: Remove all the coments in the DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and test
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,43 +1,26 @@
-# Use a single base image for both build and production
 FROM node:18-alpine AS build
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy application dependency manifests to the container image.
 COPY --chown=node:node package*.json ./
 
-# Install app dependencies using the `npm ci` command for development
 RUN npm ci
 
-# Copy app source
 COPY --chown=node:node . .
 
-# Build the application
 RUN npm run build
 
-# Set NODE_ENV environment variable
 ENV NODE_ENV production
 
-# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
 RUN npm ci --only=production && npm cache clean --force
 
-# Set the user to node
 USER node
 
-###################
-# PRODUCTION
-###################
-
-# Use the built app image as the base for the production image
 FROM node:18-alpine AS production
 
-# Create app directory
 WORKDIR /usr/src/app
 
-# Copy the bundled code and production dependencies from the build stage to the production image
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
-# Start the server using the production build
 CMD [ "node", "dist/main.js" ]


### PR DESCRIPTION
This pull request fixes #194.

The issue has been successfully resolved. The changes show that all comment lines (those starting with #) have been completely removed from both Dockerfile and src/Dockerfile while preserving all the functional commands. Specifically:

1. All descriptive comments that were prefixed with # have been removed
2. The section separator (###################) has been removed
3. The actual Docker instructions (FROM, WORKDIR, COPY, RUN, ENV, USER, CMD) remain intact and unchanged
4. The functionality of the Dockerfile remains exactly the same, as only documentation was removed
5. The multi-stage build structure is preserved with both 'build' and 'production' stages

The changes fully address the original issue request to "Remove all the comments in the DockerFile" while maintaining the operational integrity of the build process. The Dockerfiles will produce identical container images as before, just without the explanatory comments.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌